### PR TITLE
Potential fix for code scanning alert no. 1: Incorrect conversion between integer types

### DIFF
--- a/internal/provider/dns_record_resource.go
+++ b/internal/provider/dns_record_resource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"math"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -417,7 +418,7 @@ func (r *DNSRecordResource) Read(ctx context.Context, req resource.ReadRequest, 
 
 		// For MX records, match on priority and data
 		if recordType == "MX" {
-			if (priority > 0 && record.RData.Preference != int(priority)) ||
+			if (priority > 0 && (priority < int64(math.MinInt32) || priority > int64(math.MaxInt32) || record.RData.Preference != int(priority))) ||
 				(recordData != "" && record.RData.Exchange != recordData) {
 				continue
 			}

--- a/internal/provider/dns_record_resource.go
+++ b/internal/provider/dns_record_resource.go
@@ -3,9 +3,9 @@ package provider
 import (
 	"context"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
-	"math"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"


### PR DESCRIPTION
Potential fix for [https://github.com/kusold/terraform-provider-technitium-dns-server/security/code-scanning/1](https://github.com/kusold/terraform-provider-technitium-dns-server/security/code-scanning/1)

We need to ensure that when converting the `int64` value `priority` (parsed from potentially untrusted input) to an `int`, we do not allow values that exceed the range of the target type (`int`). The best way to fix this, without changing the existing logic, is to add a bounds check before the conversion, so that only values in the valid `int` range (i.e., between `math.MinInt32` and `math.MaxInt32` for 32-bit systems, or `math.MinInt64` and `math.MaxInt64` for 64-bit systems) are cast to `int`. Since Go's `int` size is platform dependent, but `record.RData.Preference` is of type `int`, we must check for the correct range.

Assuming we want to be safe on all platforms, we should check that the value of `priority` fits within `math.MinInt32` and `math.MaxInt32` before casting. For extra safety and clarity, we can use those constants in our bounds check. If `priority` is out of bounds, we can skip the comparison or fail to match, as appropriate to the logic. The only place we need to change is the conditional on line 420. We will need to import `math`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
